### PR TITLE
Bump supported Django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="aca-it@uw.edu",
     include_package_data=True,
     install_requires=[
-        'Django>=2.1,<3.2',
+        'Django>=2.1,<3.3',
         'python3-saml~=1.10',
         'mock'
     ],


### PR DESCRIPTION
Support Django version 3.2.4, as to resolve the following security vulnerability https://github.com/uw-it-aca/canvas-analytics/security/dependabot/setup.py/Django/open